### PR TITLE
Add example for Bedrock usage.

### DIFF
--- a/Track 2 (LLMs for EO)/requirements.txt
+++ b/Track 2 (LLMs for EO)/requirements.txt
@@ -1,0 +1,8 @@
+langchain-aws
+bitsandbytes
+datasets
+langchain_community
+pypdf
+sentence-transformers
+faiss-cpu
+langchain_huggingface

--- a/Track 2 (LLMs for EO)/use_bedrock.ipynb
+++ b/Track 2 (LLMs for EO)/use_bedrock.ipynb
@@ -1,0 +1,133 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.chains.combine_documents import create_stuff_documents_chain\n",
+    "\n",
+    "from langchain.prompts import PromptTemplate,  ChatPromptTemplate\n",
+    "from langchain_core.output_parsers import StrOutputParser\n",
+    "# Define the prompt template for the LLM\n",
+    "\n",
+    "from langchain.memory import ChatMessageHistory\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Define the system message\n",
+    "llm = Bedrock(model_id='arn:aws:bedrock:us-west-2:637423382292:imported-model/7i06g1utels3', region_name='us-west-2', provider='meta')\n",
+    "\n",
+    "system_message = '''You are an expert assistant that answers questions about different topics.\n",
+    "\n",
+    "You are given some extracted parts from science papers along with a question.\n",
+    "\n",
+    "If you don't know the answer, just say \"I don't know.\" Don't try to make up an answer.\n",
+    "\n",
+    "Use only the following pieces of context to answer the question at the end.\n",
+    "\n",
+    "Do not use any prior knowledge.'''\n",
+    "\n",
+    "from langchain.prompts import SystemMessagePromptTemplate, AIMessagePromptTemplate, HumanMessagePromptTemplate\n",
+    "\n",
+    "template= '''<|system|>\n",
+    "{message}\n",
+    "<|end|>\n",
+    "'''\n",
+    "\n",
+    "# A human message will contain the question and the context. The context will be automatically added by the retriever.\n",
+    "human_template = '''<|user|>\n",
+    "Context: {context}\n",
+    "\n",
+    "Question is below:\n",
+    "\n",
+    "Question: {question}\n",
+    "\n",
+    "<|end|>\n",
+    "<|assistant|>\n",
+    "'''\n",
+    "\n",
+    "\n",
+    "assistant_template = '''<|assistant|>\n",
+    "{message}\n",
+    "<|end|>\n",
+    "'''\n",
+    "\n",
+    "# Define the templates\n",
+    "SystemMessageTemplate = SystemMessagePromptTemplate.from_template(template)\n",
+    "HumanMessageTemplate = HumanMessagePromptTemplate.from_template(human_template)\n",
+    "AIMessageTemplate = AIMessagePromptTemplate.from_template(assistant_template)\n",
+    "\n",
+    "system_msg = SystemMessageTemplate.format(message=system_message)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.prompts import MessagesPlaceholder, PromptTemplate, ChatPromptTemplate\n",
+    "\n",
+    "chat_template = ChatPromptTemplate.from_messages(\n",
+    "    messages=[\n",
+    "    system_msg,\n",
+    "    human_template,\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "# As we can see our prompt is expecting three variables to be filled\n",
+    "print(chat_template)\n",
+    "\n",
+    "rag_chain = chat_template | llm | StrOutputParser()\n",
+    "\n",
+    "response = rag_chain.invoke({\"question\": 'What bands are available in HLS?', \"context\": [\"The Harmonized Landsat and Sentinel-2 (HLS) project is an extension of research conducted at NASA's Goddard Space Flight Center in Greenbelt, MD, that takes input data from the joint NASA/USGS Landsat 8 and Landsat 9 and the ESA (European Space Agency) Sentinel-2A, Sentinel-2B, and Sentinel-2C satellites to generate a harmonized, analysis-ready surface reflectance data product with observations every two to three days.\", \"The HLS project is a major outcome of the Satellite Needs Working Group assessment in 2016. In that assessment, federal agencies and end users identified a need for more frequent Landsat-like observations to track short-term changes in vegetation and other land components to support agricultural monitoring and land cover classification at moderate to high resolution in both the visible and thermal components of the electromagnetic spectrum. Spectral similarities between the Landsat 8 Operational Land Imager (OLI), the Landsat 9 OLI-2, and the Sentinel-2 MultiSpectral Instrument (MSI) present an opportunity to harmonize data from these sensors to generate higher-frequency imagery products for land surface monitoring and applications.\", \"Previous versions of HLS data products produced by the HLS Science Team at Goddard had limited spatial coverage — only covering North America and other select global locations. The current version of the HLS algorithm is a cloud-based software stack that expands the spatial coverage to include all land masses globally, outside of Antarctica.\", \"HLS Harmonized Landsat and Sentinel-2 The Harmonized Landsat and Sentinel-2 (HLS) project is an extension of research conducted at NASA's Goddard Space Flight Center in Greenbelt, MD, that takes input data from the joint NASA/USGS Landsat 8 and Landsat 9 and the ESA (European Space Agency) Sentinel-2A, Sentinel-2B, and Sentinel-2C satellites to generate a harmonized, analysis-ready surface reflectance data product with observations every two to three days.The HLS project is a major outcome of the Satellite Needs Working Group assessment in 2016. In that assessment, federal agencies and end users identified a need for more frequent Landsat-like observations to track short-term changes in vegetation and other land components to support agricultural monitoring and land cover classification at moderate to high resolution in both the visible and thermal components of the electromagnetic spectrum. Spectral similarities between the Landsat 8 Operational Land Imager (OLI), the Landsat 9 OLI-2, and the Sentinel-2 MultiSpectral Instrument (MSI) present an opportunity to harmonize data from these sensors to generate higher-frequency imagery products for land surface monitoring and applications.Previous versions of HLS data products produced by the HLS Science Team at Goddard had limited spatial coverage — only covering North America and other select global locations. The current version of the HLS algorithm is a cloud-based software stack that expands the spatial coverage to include all land masses globally, outside of Antarctica.Two data products are generated as part of the HLS project: the L30 data product generated with Landsat 8 and Landsat 9 data, and the S30 product generated using Sentinel-2 data. These data are available through Earthdata Search as well as through NASA's Land Processes Distributed Active Archive Center (LP DAAC). Feedback or questions about HLS data products can be made in the Earthdata Forum for HLS.\"]})\n",
+    "\n",
+    "print(response)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.12 ('base')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "8987afb44532b2110e1a5e1b229dd281f8440b44477d285826a54acdd52d8797"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR contains a notebook, and requirements file for use of bedrock for Eve usage.

Considerations:
- The current "deployed" instance of Eve is based on older weights.
- This notebook will run smoothly inside the sagemaker environment.
- To use:
  - Clone this repository or copy the notebook (along with requirements file) into the jupyterlab environment.
  - Run the notebook